### PR TITLE
Respect `sourcekit-lsp` from $PATH

### DIFF
--- a/src/swift.rs
+++ b/src/swift.rs
@@ -10,8 +10,16 @@ impl zed::Extension for SwiftExtension {
     fn language_server_command(
         &mut self,
         _server_id: &zed::LanguageServerId,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
+        if let Some(path) = worktree.which("sourcekit-lsp") {
+            return Ok(zed::Command {
+                command: path,
+                args: Default::default(),
+                env: worktree.shell_env(),
+            });
+        }
+
         Ok(zed::Command {
             command: "/usr/bin/xcrun".into(),
             args: vec!["sourcekit-lsp".into()],


### PR DESCRIPTION
This PR makes it so the extension will first check to see if `sourcekit-lsp` is already on the $PATH before trying to use `/usr/bin/xcrun sourcekit-lsp`.

Resolves https://github.com/zed-industries/zed/issues/13302.