### PR TITLE
Add `swiftinterface` as a possible file extension

### DIFF
--- a/languages/swift/config.toml
+++ b/languages/swift/config.toml
@@ -1,6 +1,6 @@
 name = "Swift"
 grammar = "swift"
-path_suffixes = ["swift"]
+path_suffixes = ["swift", "swiftinterface"]
 line_comments = ["//"]
 block_comment = ["/*", "*/"]
 autoclose_before = ")}]"


### PR DESCRIPTION
This is useful when navigating to imports with `sourcekit-lsp`