### PR TITLE
Fix repository link (`extension.toml`)

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -7,7 +7,7 @@ authors = [
     "ejjonny <https://github.com/ejjonny>",
     "Samuser107 L.Longheval <samuser107@gmail.com>",
 ]
-repository = "https://github.com/zed-industries/zed"
+repository = "https://github.com/zed-extensions/swift"
 
 [language_servers.sourcekit-lsp]
 name = "sourcekit-lsp"


### PR DESCRIPTION
I was a lil disoriented when I clicked the GitHub link in Zed for this extension and couldn't find it anywhere