### PR TITLE
Update `repository` extensions metadata

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -7,7 +7,7 @@ authors = [
     "ejjonny <https://github.com/ejjonny>",
     "Samuser107 L.Longheval <samuser107@gmail.com>",
 ]
-repository = "https://github.com/zed-industries/zed"
+repository = "https://github.com/zed-extensions/swift"
 
 [language_servers.sourcekit-lsp]
 name = "sourcekit-lsp"


### PR DESCRIPTION
Updates the `repository` field in `extension.toml` to point to this repository instead of the Zed repository, since the extension is no longer a part of the Zed repository (I am making an assumption that it once was).