### PR TITLE
Bump to v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "zed_swift"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "swift"
 name = "Swift"
 description = "Swift support."
-version = "0.4.2"
+version = "0.4.3"
 schema_version = 1
 authors = [
     "ejjonny <https://github.com/ejjonny>",


### PR DESCRIPTION
There was a bug in zed_extension_cli that prevented debug adapters in extensions from being successfully registered. zed_extension_cli has been fixed (https://github.com/zed-industries/extensions/pull/2927), but we need to bump the version of this and the Swift extension so they'll get rebuild and republished using the fixed CLI.

There are no functional changes in this release.