### PR TITLE
Export useful variables from test runnables and create tasks for tests

### DIFF
--- a/languages/swift/runnables.scm
+++ b/languages/swift/runnables.scm
@@ -1,4 +1,11 @@
-;; @Suite struct TestSuite
+;; Tags are named according to which testing library the test uses:
+;; swift-testing-* = Swift Testing library
+;; swift-xctest-* = XCTest library
+;;
+;; While the tasks defined in this extension don't care which library is used,
+;; other tasks built by users might.
+
+;; @Suite struct/class
 (
   (class_declaration
     (modifiers
@@ -8,25 +15,79 @@
         )
       )
     )
-    name: (type_identifier) @_name
-  ) @_swift-test-suite
-  (#set! tag swift-test-suite)
+    name: (type_identifier) @_name @SWIFT_TEST_CLASS
+  ) @_swift-testing-suite
+  (#set! tag swift-testing-suite)
 )
 
-;; @Test test func
+;; @Test top-level func
 (
-  (function_declaration
-    (modifiers
-      (attribute
-        (user_type
-          (type_identifier) @run (#eq? @run "Test")
+    (source_file
+        (function_declaration
+        (modifiers
+            (attribute
+            (user_type
+                (type_identifier) @run (#eq? @run "Test")
+            )
+            )
         )
+        name: (simple_identifier) @_name @SWIFT_TEST_FUNC
+        ) @_swift-testing-bare-func
+    )
+    (#set! tag swift-testing-bare-func)
+)
+
+;; @Test within struct/class
+(
+  (class_declaration
+    name: (type_identifier) @_name @SWIFT_TEST_CLASS
+    body: (class_body
+      (function_declaration
+        (modifiers
+            (attribute
+                (user_type
+                (type_identifier) @run (#eq? @run "Test")
+                )
+            )
+            )
+            name: (simple_identifier) @_name @SWIFT_TEST_FUNC
       )
     )
-    name: (simple_identifier) @_name
-  ) @_swift-test-test
-  (#set! tag swift-test-test)
+  ) @_swift-testing-member-func
+  (#set! tag swift-testing-member-func)
 )
+
+;; XCTestCase subclass
+(
+  (class_declaration
+    name: (type_identifier) @SWIFT_TEST_CLASS
+    (inheritance_specifier
+      inherits_from: (user_type
+        (type_identifier) @run (#eq? @run "XCTestCase")
+      )
+    )
+  ) @_swift-xctest-class
+  (#set! tag swift-xctest-class)
+)
+
+;; Test function within XCTestCase
+(
+  (class_declaration
+    name: (type_identifier) @SWIFT_TEST_CLASS
+    (inheritance_specifier
+      inherits_from: (user_type
+        (type_identifier) @_superclass_name (#eq? @_superclass_name "XCTestCase")
+      )
+    )
+    body: (class_body
+      (function_declaration
+        name: (simple_identifier) @_name @SWIFT_TEST_FUNC @run (#match? @run "^test")
+      )
+    )
+  ) @_swift-xctest-func
+  (#set! tag swift-xctest-func)
+)
+
 
 ;; QuickSpec subclass
 (
@@ -52,34 +113,4 @@
     )
   ) @_swift-test-async-spec
   (#set! tag swift-test-async-spec)
-)
-
-;; XCTestCase subclass
-(
-  (class_declaration
-    name: (type_identifier) @_name
-    (inheritance_specifier
-      inherits_from: (user_type
-        (type_identifier) @run (#eq? @run "XCTestCase")
-      )
-    )
-  ) @_swift-test-test-case
-  (#set! tag swift-test-test-case)
-)
-
-;; Test function within XCTestCase
-(
-  (class_declaration
-    (inheritance_specifier
-      inherits_from: (user_type
-        (type_identifier) @test_class_name (#eq? @test_class_name "XCTestCase")
-      )
-    )
-    body: (class_body
-      (function_declaration
-        name: (simple_identifier) @_name @run (#match? @run "^test")
-      )
-    )
-  ) @_swift-test-func
-  (#set! tag swift-test-func)
 )

--- a/languages/swift/tasks.json
+++ b/languages/swift/tasks.json
@@ -1,16 +1,33 @@
 [
-  // These don't yet work: `swift test --filter` only supports Symbols (not filenames)
-  // {
-  //   "label": "swift test",
-  //   "command": "swift",
-  //   "args": ["test", "--filter", "${ZED_STEM}"],
-  //   "tags": [
-  //     "swift-test-async-spec",
-  //     "swift-test-quick-spec",
-  //     "swift-test-func",
-  //     "swift-test-suite",
-  //     "swift-test-test-case",
-  //     "swift-test-test"
-  //   ]
-  // }
+    // The first component of a test specifier is the test target name. Since we don't
+    // know that here, our filters match any leading word.
+    //
+    // Test specifiers can be listed with "swift test list".
+
+    {
+        "label": "$ZED_CUSTOM_SWIFT_TEST_CLASS test",
+        "command": "swift",
+        "args": ["test", "--filter", "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_CLASS/'"],
+        "tags": ["swift-xctest-class", "swift-testing-suite"]
+    },
+    {
+        "label": "$ZED_CUSTOM_SWIFT_TEST_CLASS.$ZED_CUSTOM_SWIFT_TEST_FUNC test",
+        "command": "swift",
+        "args": [
+            "test",
+            "--filter",
+            "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_CLASS/$ZED_CUSTOM_SWIFT_TEST_FUNC\\b'"
+        ],
+        "tags": ["swift-xctest-func", "swift-testing-member-func"]
+    },
+    {
+        "label": "$ZED_CUSTOM_SWIFT_TEST_FUNC test",
+        "command": "swift",
+        "args": [
+            "test",
+            "--filter",
+            "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_FUNC\\b'"
+        ],
+        "tags": ["swift-testing-bare-func"]
+    }
 ]


### PR DESCRIPTION
Added tasks to enable test execution using runnable triangles. Supports both XCTest and Swift Testing libraries.

Runnables now export useful variables, which enables users to write custom testing tasks (e.g. for xcode projects – outside the scope of this plugin).

Note I'm not really clear on the reason for the underscore captures like @_name and @_tag-name in the existing code, so I've mostly left @_name in place and created @_tag-name ones. Let me know if I've done something wrong.

I haven't done anything for Quick tests (not a Quick user, and it's not an Apple library) and have left those runnables as-is.