### PR TITLE
Bump version to v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "zed_swift"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_swift"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 publish = false
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "swift"
 name = "Swift"
 description = "Swift support."
-version = "0.4.3"
+version = "0.4.4"
 schema_version = 1
 authors = [
     "ejjonny <https://github.com/ejjonny>",


### PR DESCRIPTION
This PR bumps the version of the extension to 0.4.4.

Included: 
- https://github.com/zed-extensions/swift/pull/42
- https://github.com/zed-extensions/swift/pull/43