### PR TITLE
Runnable support for indirect subclasses of XCTestCase 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,16 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "cc"
+version = "1.2.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -63,6 +82,12 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
@@ -418,6 +443,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +517,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -528,6 +588,32 @@ name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -746,6 +832,8 @@ version = "0.4.6"
 dependencies = [
  "serde",
  "serde_json",
+ "tree-sitter",
+ "tree-sitter-swift",
  "zed_extension_api",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -550,6 +551,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -591,12 +598,16 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -607,9 +618,9 @@ checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "tree-sitter-swift"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -832,6 +843,7 @@ version = "0.4.6"
 dependencies = [
  "serde",
  "serde_json",
+ "streaming-iterator",
  "tree-sitter",
  "tree-sitter-swift",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ crate-type = ["cdylib"]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 zed_extension_api = "0.6.0"
+
+[dev-dependencies]
+tree-sitter = "0.20"
+tree-sitter-swift = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ serde_json = "1.0.140"
 zed_extension_api = "0.6.0"
 
 [dev-dependencies]
-tree-sitter = "0.20"
-tree-sitter-swift = "0.6"
+tree-sitter = "0.25"
+tree-sitter-swift = "0.7"
+streaming-iterator = "0.1"

--- a/languages/swift/runnables.scm
+++ b/languages/swift/runnables.scm
@@ -107,25 +107,21 @@
 ;; This pattern allows users to mark indirect subclasses (MyTests <- MyTestsBase <- XCTestCase)
 ;; by adding a "// @XCTestClass" comment before the class declaration.
 (
-  (source_file
-    (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
-    (class_declaration
-      name: (type_identifier) @SWIFT_TEST_CLASS
-    )
+  (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
+  (class_declaration
+    name: (type_identifier) @SWIFT_TEST_CLASS @run
   ) @_swift-xctest-class
   (#set! tag swift-xctest-class)
 )
 
 ;; Test function within comment-annotated XCTest class
 (
-  (source_file
-    (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
-    (class_declaration
-      name: (type_identifier) @SWIFT_TEST_CLASS
-      body: (class_body
-        (function_declaration
-          name: (simple_identifier) @_name @SWIFT_TEST_FUNC @run (#match? @run "^test")
-        )
+  (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
+  (class_declaration
+    name: (type_identifier) @SWIFT_TEST_CLASS
+    body: (class_body
+      (function_declaration
+        name: (simple_identifier) @_name @SWIFT_TEST_FUNC @run (#match? @run "^test")
       )
     )
   ) @_swift-xctest-func

--- a/languages/swift/runnables.scm
+++ b/languages/swift/runnables.scm
@@ -4,6 +4,21 @@
 ;;
 ;; While the tasks defined in this extension don't care which library is used,
 ;; other tasks built by users might.
+;;
+;; INDIRECT XCTEST SUBCLASSES:
+;; Tree-sitter queries cannot follow inheritance chains semantically, so indirect
+;; subclasses (MyTests <- MyTestsBase <- XCTestCase) are not automatically detected.
+;;
+;; WORKAROUND: Add a // @XCTestClass comment before indirect subclass declarations:
+;;
+;;   class MyTestsBase: XCTestCase { }
+;;
+;;   // @XCTestClass
+;;   class MyTests: MyTestsBase {
+;;       func testSomething() { }
+;;   }
+;;
+;; This allows the query to recognize and run tests in indirect subclasses.
 
 ;; @Suite struct/class
 (
@@ -88,6 +103,34 @@
   (#set! tag swift-xctest-func)
 )
 
+;; XCTestCase indirect subclass with @XCTestClass comment annotation
+;; This pattern allows users to mark indirect subclasses (MyTests <- MyTestsBase <- XCTestCase)
+;; by adding a "// @XCTestClass" comment before the class declaration.
+(
+  (source_file
+    (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
+    (class_declaration
+      name: (type_identifier) @SWIFT_TEST_CLASS
+    )
+  ) @_swift-xctest-class
+  (#set! tag swift-xctest-class)
+)
+
+;; Test function within comment-annotated XCTest class
+(
+  (source_file
+    (comment) @_marker (#match? @_marker ".*@XCTestClass.*")
+    (class_declaration
+      name: (type_identifier) @SWIFT_TEST_CLASS
+      body: (class_body
+        (function_declaration
+          name: (simple_identifier) @_name @SWIFT_TEST_FUNC @run (#match? @run "^test")
+        )
+      )
+    )
+  ) @_swift-xctest-func
+  (#set! tag swift-xctest-func)
+)
 
 ;; QuickSpec subclass
 (

--- a/src/runnables_test.rs
+++ b/src/runnables_test.rs
@@ -62,7 +62,7 @@
 //!
 //! Example:
 //!
-//! ```rust
+//! ```rust,ignore
 //! #[test]
 //! fn test_new_framework() {
 //!     let source = r#"
@@ -100,12 +100,12 @@ mod tests {
 
     fn get_query() -> &'static Query {
         static QUERY: OnceLock<Query> = OnceLock::new();
-        QUERY.get_or_init(|| Query::new(&get_language(), RUNNABLES_QUERY).unwrap())
+        QUERY.get_or_init(|| Query::new(get_language(), RUNNABLES_QUERY).unwrap())
     }
 
     fn setup_parser() -> Parser {
         let mut parser = Parser::new();
-        parser.set_language(&get_language()).unwrap();
+        parser.set_language(get_language()).unwrap();
         parser
     }
 
@@ -126,7 +126,7 @@ mod tests {
                 let capture_name = &query.capture_names()[capture.index as usize];
                 let text = capture.node.utf8_text(source.as_bytes()).unwrap();
 
-                match capture_name.as_ref() {
+                match *capture_name {
                     "SWIFT_TEST_CLASS" => class_name = text.to_string(),
                     "SWIFT_TEST_FUNC" => func_name = text.to_string(),
                     _ => {}
@@ -135,7 +135,7 @@ mod tests {
 
             // Get the tag from pattern properties
             if let Some(props) = match_.pattern_index.checked_sub(0) {
-                for prop in query.property_settings(props as usize) {
+                for prop in query.property_settings(props) {
                     if prop.key.as_ref() == "tag" {
                         if let Some(value) = &prop.value {
                             tag = value.to_string();
@@ -690,7 +690,7 @@ class MyOtherTests: BaseTestCase {
 
         // If we got here, the query compiled successfully
         assert!(
-            query.capture_names().len() > 0,
+            !query.capture_names().is_empty(),
             "Query should have capture names"
         );
     }

--- a/src/runnables_test.rs
+++ b/src/runnables_test.rs
@@ -1,0 +1,373 @@
+#[cfg(test)]
+mod tests {
+    use tree_sitter::{Parser, Query, QueryCursor};
+
+    const RUNNABLES_QUERY: &str = include_str!("../languages/swift/runnables.scm");
+
+    fn setup_parser() -> Parser {
+        let mut parser = Parser::new();
+        let language = unsafe {
+            let ptr = tree_sitter_swift::LANGUAGE.into_raw()();
+            std::mem::transmute(ptr)
+        };
+        parser.set_language(language).unwrap();
+        parser
+    }
+
+    fn get_captures(source: &str, query_str: &str) -> Vec<(String, String, String)> {
+        let mut parser = setup_parser();
+        let tree = parser.parse(source, None).unwrap();
+        let language = unsafe {
+            let ptr = tree_sitter_swift::LANGUAGE.into_raw()();
+            std::mem::transmute(ptr)
+        };
+        let query = Query::new(language, query_str).unwrap();
+        let mut cursor = QueryCursor::new();
+
+        let mut results = Vec::new();
+        for match_ in cursor.matches(&query, tree.root_node(), source.as_bytes()) {
+            let mut tag = String::new();
+            let mut class_name = String::new();
+            let mut func_name = String::new();
+
+            for capture in match_.captures {
+                let capture_name = &query.capture_names()[capture.index as usize];
+                let text = capture.node.utf8_text(source.as_bytes()).unwrap();
+
+                match capture_name.as_ref() {
+                    "SWIFT_TEST_CLASS" => class_name = text.to_string(),
+                    "SWIFT_TEST_FUNC" => func_name = text.to_string(),
+                    _ => {}
+                }
+            }
+
+            // Get the tag from pattern properties
+            if let Some(props) = match_.pattern_index.checked_sub(0) {
+                for prop in query.property_settings(props as usize) {
+                    if prop.key.as_ref() == "tag" {
+                        if let Some(value) = &prop.value {
+                            tag = value.to_string();
+                        }
+                    }
+                }
+            }
+
+            results.push((tag, class_name, func_name));
+        }
+
+        results
+    }
+
+    #[test]
+    fn test_swift_testing_suite() {
+        let source = r#"
+@Suite
+struct MyTestSuite {
+    @Test func testSomething() {}
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        // Should capture the @Suite struct
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, _)| tag == "swift-testing-suite" && class == "MyTestSuite"),
+            "Expected to find swift-testing-suite tag for MyTestSuite, got: {:?}",
+            captures
+        );
+    }
+
+    #[test]
+    fn test_swift_testing_suite_class() {
+        let source = r#"
+@Suite
+class MyTestClass {
+    @Test func testSomething() {}
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, _)| tag == "swift-testing-suite" && class == "MyTestClass"),
+            "Expected to find swift-testing-suite tag for MyTestClass"
+        );
+    }
+
+    #[test]
+    fn test_swift_testing_bare_func() {
+        let source = r#"
+@Test func testTopLevelFunction() {
+    // test code
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, func)| tag == "swift-testing-bare-func"
+                    && func == "testTopLevelFunction"),
+            "Expected to find swift-testing-bare-func tag for testTopLevelFunction"
+        );
+    }
+
+    #[test]
+    fn test_swift_testing_member_func() {
+        let source = r#"
+struct TestSuite {
+    @Test func testMemberFunction() {
+        // test code
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, func)| tag == "swift-testing-member-func"
+                    && class == "TestSuite"
+                    && func == "testMemberFunction"),
+            "Expected to find swift-testing-member-func tag"
+        );
+    }
+
+    #[test]
+    fn test_xctest_class() {
+        let source = r#"
+import XCTest
+
+class MyTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, _)| tag == "swift-xctest-class" && class == "MyTests"),
+            "Expected to find swift-xctest-class tag for MyTests"
+        );
+    }
+
+    #[test]
+    fn test_xctest_func() {
+        let source = r#"
+class MyTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+
+    func testAnotherThing() {
+        XCTAssertEqual(1, 1)
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, func)| tag == "swift-xctest-func"
+                    && class == "MyTests"
+                    && func == "testExample"),
+            "Expected to find swift-xctest-func tag for testExample"
+        );
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, func)| tag == "swift-xctest-func"
+                    && class == "MyTests"
+                    && func == "testAnotherThing"),
+            "Expected to find swift-xctest-func tag for testAnotherThing"
+        );
+    }
+
+    #[test]
+    fn test_xctest_func_requires_test_prefix() {
+        let source = r#"
+class MyTests: XCTestCase {
+    func setUp() {
+        // setup code
+    }
+
+    func helperMethod() {
+        // not a test
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        // setUp and helperMethod should NOT be captured as they don't start with "test"
+        assert!(
+            !captures
+                .iter()
+                .any(|(tag, _, func)| tag == "swift-xctest-func" && func == "setUp"),
+            "setUp should not be captured as a test function"
+        );
+
+        assert!(
+            !captures
+                .iter()
+                .any(|(tag, _, func)| tag == "swift-xctest-func" && func == "helperMethod"),
+            "helperMethod should not be captured as a test function"
+        );
+    }
+
+    #[test]
+    fn test_quick_spec() {
+        let source = r#"
+import Quick
+import Nimble
+
+class MyQuickSpec: QuickSpec {
+    override func spec() {
+        describe("something") {
+            it("does something") {
+                expect(true).to(beTrue())
+            }
+        }
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, _)| tag == "swift-test-quick-spec"),
+            "Expected to find swift-test-quick-spec tag"
+        );
+    }
+
+    #[test]
+    fn test_async_spec() {
+        let source = r#"
+import Quick
+import Nimble
+
+class MyAsyncSpec: AsyncSpec {
+    override func spec() {
+        describe("async operations") {
+            it("does async work") {
+                await someAsyncFunction()
+            }
+        }
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, _)| tag == "swift-test-async-spec"),
+            "Expected to find swift-test-async-spec tag"
+        );
+    }
+
+    #[test]
+    fn test_multiple_test_types_in_same_file() {
+        let source = r#"
+@Test func topLevelTest() {}
+
+@Suite
+struct SwiftTestingSuite {
+    @Test func swiftTestingTest() {}
+}
+
+class XCTestSuite: XCTestCase {
+    func testXCTest() {}
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        // Should find all three types of tests
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, _)| tag == "swift-testing-bare-func"),
+            "Should find bare test function"
+        );
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, _)| tag == "swift-testing-suite"),
+            "Should find Swift Testing suite"
+        );
+
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, _, _)| tag == "swift-xctest-class"),
+            "Should find XCTest class"
+        );
+    }
+
+    #[test]
+    fn test_nested_classes_not_confused() {
+        let source = r#"
+class OuterTests: XCTestCase {
+    func testOuter() {}
+
+    class Inner {
+        func testInner() {}
+    }
+}
+"#;
+
+        let captures = get_captures(source, RUNNABLES_QUERY);
+
+        // Only testOuter should be captured as it's in the XCTestCase subclass
+        assert!(
+            captures
+                .iter()
+                .any(|(tag, class, func)| tag == "swift-xctest-func"
+                    && class == "OuterTests"
+                    && func == "testOuter"),
+            "Should find testOuter in XCTestCase"
+        );
+
+        // testInner should NOT be captured as it's in a nested class that doesn't inherit from XCTestCase
+        let inner_test_count = captures
+            .iter()
+            .filter(|(tag, _, func)| tag == "swift-xctest-func" && func == "testInner")
+            .count();
+
+        assert_eq!(inner_test_count, 0, "testInner should not be captured");
+    }
+
+    #[test]
+    fn test_query_is_valid() {
+        // This test ensures the query itself is syntactically valid
+        let language = unsafe {
+            let ptr = tree_sitter_swift::LANGUAGE.into_raw()();
+            std::mem::transmute(ptr)
+        };
+        let result = Query::new(language, RUNNABLES_QUERY);
+
+        assert!(
+            result.is_ok(),
+            "Runnables query should be valid: {:?}",
+            result.err()
+        );
+    }
+}

--- a/src/runnables_test.rs
+++ b/src/runnables_test.rs
@@ -1,3 +1,85 @@
+//! # Runnables Tests
+//!
+//! Unit tests for the Swift runnables tree-sitter query file (`languages/swift/runnables.scm`).
+//!
+//! ## Overview
+//!
+//! The runnables query is used by Zed to identify test functions and test classes in Swift code.
+//! The tests validate that the query correctly captures:
+//!
+//! 1. **Swift Testing Framework** (modern Swift 6+ testing)
+//!    - `@Suite` annotations on structs and classes
+//!    - `@Test` annotations on top-level functions
+//!    - `@Test` annotations on member functions within test suites
+//!
+//! 2. **XCTest Framework** (traditional Swift testing)
+//!    - Classes that inherit from `XCTestCase`
+//!    - Classes marked with `@XCTestCase` comment annotation (for indirect subclasses)
+//!    - Test methods within XCTest classes (must start with `test` prefix)
+//!
+//! 3. **Quick/Nimble Framework** (BDD-style testing)
+//!    - `QuickSpec` subclasses
+//!    - `AsyncSpec` subclasses
+//!
+//! ## Running Tests
+//!
+//! ```bash
+//! # Run all tests
+//! cargo test --lib
+//!
+//! # Run only the runnables tests
+//! cargo test --lib runnables_test
+//! ```
+//!
+//! ## Test Structure
+//!
+//! Each test:
+//! 1. Defines a Swift code snippet containing test code
+//! 2. Parses the code using tree-sitter-swift
+//! 3. Runs the runnables query against the parsed tree
+//! 4. Validates that the correct captures are returned with the appropriate tags
+//!
+//! ## Tags
+//!
+//! The query assigns tags to different types of test definitions:
+//!
+//! - `swift-testing-suite` - A struct/class with `@Suite` annotation
+//! - `swift-testing-bare-func` - A top-level function with `@Test` annotation
+//! - `swift-testing-member-func` - A member function with `@Test` annotation within a suite
+//! - `swift-xctest-class` - A class that inherits from `XCTestCase` or is marked with `@XCTestCase` comment
+//! - `swift-xctest-func` - A test method within an XCTest class
+//! - `swift-test-quick-spec` - A QuickSpec subclass
+//! - `swift-test-async-spec` - An AsyncSpec subclass
+//!
+//! ## Adding New Tests
+//!
+//! When adding support for new test frameworks or patterns:
+//!
+//! 1. Add a new test function in this module
+//! 2. Create a Swift code snippet that demonstrates the pattern
+//! 3. Use `get_captures()` to run the query
+//! 4. Assert that the expected tags and names are captured
+//!
+//! Example:
+//!
+//! ```rust
+//! #[test]
+//! fn test_new_framework() {
+//!     let source = r#"
+//! // Your Swift test code here
+//! "#;
+//!
+//!     let captures = get_captures(source, get_query());
+//!
+//!     assert!(
+//!         captures
+//!             .iter()
+//!             .any(|(tag, class, func)| tag == "expected-tag" && class == "ExpectedClass"),
+//!         "Expected to find the test pattern"
+//!     );
+//! }
+//! ```
+
 #[cfg(test)]
 mod tests {
     use std::sync::OnceLock;

--- a/src/swift.rs
+++ b/src/swift.rs
@@ -213,3 +213,6 @@ impl zed::Extension for SwiftExtension {
 }
 
 zed::register_extension!(SwiftExtension);
+
+#[cfg(test)]
+mod runnables_test;


### PR DESCRIPTION
## Add `@XCTestClass` Comment Annotation for Indirect Test Subclasses

This PR adds support for marking indirect XCTest subclasses using an `@XCTestClass` comment annotation, with comprehensive unit tests to validate the runnables query. Resolves #49.

### The Problem

Tree-sitter queries cannot traverse inheritance chains beyond the direct parent class. Classes like `class MyTests: BaseTestCase` (where `BaseTestCase: XCTestCase`) aren't detected as test classes, even though they contain valid test methods.

### The Solution

Add `@XCTestCase` comment annotation support in `languages/swift/runnables.scm`:

```swift
// @XCTestClass
class MyIndirectTests: BaseTestCase {
    func testSomething() { }  // Now recognized as a runnable test
}
```

**⚠️ AI-Generated Disclaimer**: Most of this work was generated with AI assistance. If the maintainers find this objectionable or too verbose, I'm happy to withdraw it and submit a smaller, more hand-crafted PR if the additions seem useful. I'm also open to other solutions to the problem.