### PR TITLE
Add first-line pattern detection for executable Swift scripts

### DIFF
--- a/languages/swift/config.toml
+++ b/languages/swift/config.toml
@@ -2,6 +2,7 @@ name = "Swift"
 grammar = "swift"
 path_suffixes = ["swift", "swiftinterface"]
 line_comments = ["// "]
+first_line_pattern = '^#!.*\bswift\b'
 block_comment = ["/*", "*/"]
 autoclose_before = ")}]"
 brackets = [


### PR DESCRIPTION
Add support for detecting Swift files that can be executed directly via shebangs (e.g., '#!/usr/bin/env swift' or '#!/usr/bin/swift').

This allows Zed to recognize Swift scripts with shebang lines as executable Swift files, similar to how other languages detect shebangs.

Release Notes:

- Improved: Swift language detection now recognizes executable Swift scripts with shebang lines.