### PR TITLE
Fix Swift label highlight captures

### DIFF
--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -57,10 +57,10 @@
 (where_keyword) @keyword
 
 (parameter
-  external_name: (simple_identifier) @property)
+  external_name: (simple_identifier) @variable.parameter)
 
 (parameter
-  name: (simple_identifier) @property)
+  name: (simple_identifier) @variable.parameter)
 
 (type_parameter
   (type_identifier) @property)
@@ -127,7 +127,7 @@
     (simple_identifier) @variable.parameter))
 
 (value_argument
-  name: (value_argument_label) @property)
+  name: (value_argument_label) @label)
 
 (import_declaration
   "import" @keyword.import)


### PR DESCRIPTION
## Summary

Fix Swift Tree-sitter highlight captures so function parameter labels/names and call argument labels are not classified as `@property`.

This keeps themes from having to style Swift labels the same way as real member properties.

Fixes #74.

## Test Case

The issue screenshots include this representative Swift code:

```swift
@discardableResult
func printSummary(for jobs: [BuildJob]) -> Int {
    let completed = jobs.filter { $0.state == .finished }
    let grouped = Dictionary(grouping: jobs, by: \.state)
    return completed.count
}
```

Expected captures after this change:

```text
for      -> @variable.parameter
jobs     -> @variable.parameter
grouping -> @label
by       -> @label
filter   -> @function.call
```

Before this change, `for`, `jobs`, `grouping`, and `by` were captured as `@property`.

## Validation

- Ran `tree-sitter-cli query` against the screenshot-derived Swift snippet and compared `origin/main` vs this branch.
- Confirmed the captures changed from `@property` to `@variable.parameter` / `@label` for the issue cases.
- Confirmed nearby `jobs.filter` remains captured as `@function.call`.
- Ran `cargo test`.
- Ran `git diff --check`.
