### PR TITLE
Supporting running nested SPM tests

### DIFF
--- a/languages/swift/tasks.json
+++ b/languages/swift/tasks.json
@@ -7,7 +7,7 @@
     {
         "label": "$ZED_CUSTOM_SWIFT_TEST_CLASS test",
         "command": "swift",
-        "args": ["test", "--filter", "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_CLASS/'"],
+        "args": ["test", "--package-path", "$ZED_DIRNAME", "--filter", "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_CLASS/'"],
         "tags": ["swift-xctest-class", "swift-testing-suite"]
     },
     {
@@ -15,6 +15,8 @@
         "command": "swift",
         "args": [
             "test",
+            "--package-path",
+            "$ZED_DIRNAME",
             "--filter",
             "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_CLASS/$ZED_CUSTOM_SWIFT_TEST_FUNC\\b'"
         ],
@@ -25,6 +27,8 @@
         "command": "swift",
         "args": [
             "test",
+            "--package-path",
+            "$ZED_DIRNAME",
             "--filter",
             "'^\\w+\\.$ZED_CUSTOM_SWIFT_TEST_FUNC\\b'"
         ],


### PR DESCRIPTION
**Issue**
Fixes #13

**Issue before this change**

When working in a folder where the root folder is not a SPM package, we were getting the following error:

```
error: Could not find Package.swift in this directory or any of its parent directories.
```

This happened because `swift test` was being ran without a package path, so SwiftPM tried to resolve `Package.swift` from the workspace root.

**Solution**

Add `--package-path $ZED_DIRNAME` to `swift test`.

`$ZED_DIRNAME` points to the directory of the test file we are attempting to run. Even when that directory is not the package root, SwiftPM is able to resolve the owning `Package.swift` by traversing upwards to the root of the package.

This makes it possible to run tests from nested SPM packages in a folder or workspace that contains one or many separate SPM packages.

**Testing instructions**

```sh
mkdir testing-this
cd testing-this
swift package init --package-path Nested
zed .
```

If you run the tests before this change then you will see the error above. With this fix applied, the tests can be ran successfully.